### PR TITLE
Add helper functions for hiding/showing options in dom

### DIFF
--- a/src/Hs.js
+++ b/src/Hs.js
@@ -210,16 +210,17 @@ export default class Hs {
    *
    * @param  {String} filter a filter key
    * @param  {Array} optionKeysToSet an array of optionKeys
-   * @param  {Boolean} disable whether or not to disable option visibility
+   * @param  {String} property the property
+   * @param  {Boolean} bool the boolean value to apply to the property
    */
-  setOptionVisibility (filter, optionKeysToSet, disable) {
+  setOptionPropertyToBoolean (filter, optionKeysToSet, property, bool) {
     this._validFilterKey(filter)
     let options = this.getOptionsForFilter(filter)
     for (let i = 0; i < options.length; i++) {
       if (optionKeysToSet.includes(options[i].key)) {
-        options[i].disabled = disable
-      } else if (disable) {
-        options[i].disabled = false
+        options[i][property] = bool
+      } else if (bool) {
+        options[i][property] = !bool
       }
     }
     this.setOptionsForFilter(filter, options)
@@ -233,7 +234,7 @@ export default class Hs {
    */
   disableOptions (filter, optionKeys) {
     this._validFilterKey(filter)
-    this.setOptionVisibility(filter, optionKeys, true)
+    this.setOptionPropertyToBoolean(filter, optionKeys, 'disabled', true)
   }
 
   /**
@@ -244,7 +245,29 @@ export default class Hs {
    */
   enableOptions (filter, optionKeys) {
     this._validFilterKey(filter)
-    this.setOptionVisibility(filter, optionKeys, false)
+    this.setOptionPropertyToBoolean(filter, optionKeys, 'disabled', false)
+  }
+
+  /**
+   * Set hidden property to true for given options
+   *
+   * @param  {String} filter a filter key
+   * @param  {Array} optionKeys an array of optionKeys
+   */
+  hideOptions (filter, optionKeys) {
+    this._validFilterKey(filter)
+    this.setOptionPropertyToBoolean(filter, optionKeys, 'hidden', true)
+  }
+
+  /**
+   * Set hidden property to false for given options
+   *
+   * @param  {String} filter a filter key
+   * @param  {Array} optionKeys an array of optionKeys
+   */
+  showOptions (filter, optionKeys) {
+    this._validFilterKey(filter)
+    this.setOptionPropertyToBoolean(filter, optionKeys, 'hidden', false)
   }
 
   /**

--- a/src/Hs.js
+++ b/src/Hs.js
@@ -210,7 +210,7 @@ export default class Hs {
    *
    * @param  {String} filter a filter key
    * @param  {Array} optionKeysToSet an array of optionKeys
-   * @param  {String} property the property
+   * @param  {String} property the name of the property
    * @param  {Boolean} bool the boolean value to apply to the property
    */
   setOptionPropertyToBoolean (filter, optionKeysToSet, property, bool) {

--- a/tests/unit/Hs.spec.js
+++ b/tests/unit/Hs.spec.js
@@ -161,6 +161,28 @@ describe('DV Filter functions', () => {
       })
     })
   })
+  it('Can Hide Option', () => {
+    let hs = mockHs()
+    Object.keys(page.filters()).forEach(filterKey => {
+      page.filters()[filterKey].options.forEach(option => {
+        hs.hideOptions(filterKey, [option.key])
+        let options = hs.getOptionsForFilter(filterKey)
+        let hiddenOption = options.filter(opt => opt.key === option.key)[0]
+        expect(hiddenOption.hidden).toEqual(true)
+      })
+    })
+  })
+  it('Can Show Option', () => {
+    let hs = mockHs()
+    Object.keys(page.filters()).forEach(filterKey => {
+      page.filters()[filterKey].options.forEach(option => {
+        hs.showOptions(filterKey, [option.key])
+        let options = hs.getOptionsForFilter(filterKey)
+        let shownOption = options.filter(opt => opt.key === option.key)[0]
+        expect(shownOption.hidden).toEqual(false)
+      })
+    })
+  })
 
   // TODO: Test for getFilterDefault
   // TODO: Test for getFilterDefaultLabel


### PR DESCRIPTION
Adds helper functions to set `'hidden'` property on options. Refactored `setOptionVisibility()` to  a more general function named `setOptionPropertyToBoolean()`.